### PR TITLE
Improve error handling to make it easier to debug test failures.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+npm-debug.log


### PR DESCRIPTION
https://github.com/jimbol/expect-gen/issues/1

This would be a breaking change. Specifically, it would break snapshots. Snapshots will now contain the name provided as an optional last argument for all methods, or the method type (`yields`, `next`, `finishes`).

- [ ] Tests
- [ ] Reverse assertion order to be correct