### PR TITLE
Correct return value for `finishes` in docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ expectGen(generator, [...args])
   .finishes([result])
 ```
 - Asserts that generator finishes with `result`
-- Returns same object with `run` method
+- Returns same instance `StepManager`
 
 ### run
 ```es6


### PR DESCRIPTION
Seems like there's a mistake in the docs!