### PR TITLE
Move `assert-diff` package from devDependencies to dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "0.1.2",
   "description": "Assertion library for unit testing JS generators. Works well with redux-saga. Allows snapshot testing.",
   "devDependencies": {
-    "assert-diff": "^1.2.0",
     "jest": "^19.0.2",
     "redux-saga": "^0.15.0"
+  },
+  "dependencies": {
+    "assert-diff": "^1.2.0"
   },
   "scripts": {
     "test": "jest"


### PR DESCRIPTION
I could be wrong, but I'm pretty sure this is the correct package.json config. Step Manager uses this lib at runtime, so it needs to be specified in dependencies to get installed when adding expect-gen as a devdependency