### PR TITLE
Support throw

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "assert-diff": "^1.2.0"
   },
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "test-watch": "jest --watch"
   },
   "repository": {
     "type": "git",

--- a/step-manager.js
+++ b/step-manager.js
@@ -13,8 +13,26 @@ module.exports = class StepManager {
 
   yields(expectedValue, result) {
     this.steps.push({
-      expectedValue,
       result,
+      expectedValue,
+    });
+
+    return this;
+  }
+
+  catches(error, expectedValue) {
+    this.steps.push({
+      error,
+      expectedValue,
+    });
+
+    return this;
+  }
+
+  throws(error) {
+    this.steps.push({
+      error,
+      expectedThrow: true,
     });
 
     return this;
@@ -27,8 +45,8 @@ module.exports = class StepManager {
 
   finishes(expectedValue) {
     this.steps.push({
-      expectedDone: true,
       expectedValue,
+      expectedDone: true,
     });
 
     return this;
@@ -58,16 +76,9 @@ class Runner {
 
     steps.reduce((prevResult, step) => {
       if (this.isDone) throwExtraStep(step);
+      const output = runStep(it, step, prevResult);
 
-      const output = it.next(prevResult);
-
-      if (step.expectedDone) {
-        assert.equal(output.done, true);
-      }
-
-      if (step.expectedValue) {
-        assert.deepEqual(output.value, step.expectedValue);
-      }
+      runAssertions(step, output);
 
       if (output.done) this.isDone = true;
 
@@ -78,6 +89,36 @@ class Runner {
     return this.results;
   }
 }
+
+const runStep = (it, step, prevResult) => {
+  if (step.error) {
+    try {
+      return it.throw(step.error);
+    } catch (error) {
+      return {
+        errorThrown: error,
+      };
+    }
+  }
+
+  return it.next(prevResult);
+}
+
+const runAssertions = (step, output) => {
+  if (step.expectedThrow) {
+    assert.deepEqual(output.errorThrown, step.error);
+  } else if (output.errorThrown) {
+    throw output.errorThrown;
+  }
+
+  if (step.expectedDone) {
+    assert.equal(output.done, true);
+  }
+
+  if (step.expectedValue) {
+    assert.deepEqual(output.value, step.expectedValue);
+  }
+};
 
 const throwExtraStep = (step) => {
   throw new Error({

--- a/step-manager.js
+++ b/step-manager.js
@@ -38,6 +38,16 @@ module.exports = class StepManager {
     return this;
   }
 
+  catchesAndFinishes(error, expectedValue) {
+    this.steps.push({
+      error,
+      expectedValue,
+      expectedDone: true,
+    });
+
+    return this;
+  }
+
   next(result) {
     this.steps.push({ result });
     return this;

--- a/test/step-manager.test.js
+++ b/test/step-manager.test.js
@@ -94,6 +94,42 @@ describe('StepManager', () => {
     });
   });
 
+  describe.only('#catches', () => {
+    let errEffect;
+    let myError;
+    let myIds;
+    beforeEach(() => {
+      errEffect = function* (ids) {
+        let val;
+        console.log('hi');
+        try {
+          console.log('try');
+          yield ids;
+        } catch (e) {
+          console.log('Caught:', e);
+        }
+
+        return 'THE_END';
+      }
+
+      myIds = [1, 2, 3];
+      args = [myIds];
+      myError = new Error('My error');
+      stepManager = new StepManager(errEffect, args)
+        .catches(myError, myIds);
+    });
+    //
+    // it('stores expectedValue', () => {
+    //   expect(stepManager.steps.length).toEqual(1);
+    //   expect(stepManager.steps[0].error).toBe(myError);
+    //   expect(stepManager.steps[0].expectedValue).toBe(myIds);
+    // });
+
+    it('passes result into generator', () => {
+      stepManager.finishes('THE_END').run();
+    });
+  });
+
   describe('#finishes', () => {
     beforeEach(() => {
       ids = [1, 2, 3];


### PR DESCRIPTION
https://github.com/jimbol/expect-gen/issues/15

### throws
```es6
expectGen(generator, [...args])
  .throws(error)
```
- Throws `error` into generator
- Checks that iterator throws an uncaught exception
- Returns same instance `StepManager`

### catches
```es6
expectGen(generator, [...args])
  .catches(error, [expectedValue])
```
- Throws `error` into generator
- Runs an assertion that thrown iterator will yield the `expectedValue`
- Returns same instance `StepManager`

### catchesAndFinishes
```es6
expectGen(generator, [...args])
  .catchesAndFinishes(error, [result])
```
- Throws `error` into generator
- Asserts that generator finishes with `result`
- Returns same instance `StepManager`
