### PR TITLE
Improve error messaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+npm-debug.log

--- a/index.js
+++ b/index.js
@@ -1,5 +1,10 @@
 const StepManager = require('./step-manager');
+const assert = require('assert-diff');
 
-module.exports = function expectGen(iterator, ...args) {
-  return new StepManager(iterator, args);
+module.exports = function expectGen(generator, ...args) {
+  return new StepManager({
+    generator,
+    args,
+    deepEqual: assert.deepEqual,
+  });
 }

--- a/runner.js
+++ b/runner.js
@@ -1,0 +1,71 @@
+const assert = require('assert-diff');
+module.exports = class Runner {
+  constructor(it, steps) {
+    this.it = it;
+    this.steps = steps;
+    this.results = [];
+    this.isDone = false;
+  }
+
+  run() {
+    const { it, steps } = this;
+
+    steps.reduce((prevResult, step) => {
+      if (this.isDone) throwExtraStep(step);
+
+      let output;
+      try {
+        output = runStep(it, step, prevResult);
+        runAssertions(step, output);
+      } catch (err) {
+        err.message = `${err.message}\n${step.stack}`
+        throw err;
+      }
+
+      if (output.done) this.isDone = true;
+
+      this.results.push(output);
+      return step.result;
+    }, null);
+
+    return this.results;
+  }
+}
+
+const runStep = (it, step, prevResult) => {
+  if (step.error) {
+    try {
+      return it.throw(step.error);
+    } catch (error) {
+      return {
+        errorThrown: error,
+      };
+    }
+  }
+
+  return it.next(prevResult);
+}
+
+const runAssertions = (step, output) => {
+  if (step.expectedThrow) {
+    assert.deepEqual(output.errorThrown, step.error);
+  } else if (output.errorThrown) {
+    throw output.errorThrown;
+  }
+
+  if (step.expectedDone) {
+    if (output.done !== true) throwExpectFinish(step);
+  }
+
+  if (step.expectedValue) {
+    assert.deepEqual(output.value, step.expectedValue);
+  }
+};
+
+const throwExpectFinish = () => {
+  throw new Error('Expected the generator to finish but it has more step(s) left.');
+};
+
+const throwExtraStep = () => {
+  throw new Error('Too many steps were provided for the generator');
+};

--- a/runner.js
+++ b/runner.js
@@ -1,8 +1,8 @@
-const assert = require('assert-diff');
 module.exports = class Runner {
-  constructor(it, steps) {
+  constructor(it, steps, deepEqual) {
     this.it = it;
     this.steps = steps;
+    this.deepEqual = deepEqual;
     this.results = [];
     this.isDone = false;
   }
@@ -16,9 +16,9 @@ module.exports = class Runner {
       let output;
       try {
         output = runStep(it, step, prevResult);
-        runAssertions(step, output);
+        runAssertions(step, output, this.deepEqual);
       } catch (err) {
-        err.message = `${err.message}\n${step.stack}`
+        err.stack = `\n\nStack:\n${step.stack}`;
         throw err;
       }
 
@@ -46,9 +46,9 @@ const runStep = (it, step, prevResult) => {
   return it.next(prevResult);
 }
 
-const runAssertions = (step, output) => {
+const runAssertions = (step, output, deepEqual) => {
   if (step.expectedThrow) {
-    assert.deepEqual(output.errorThrown, step.error);
+    deepEqual(output.errorThrown, step.error);
   } else if (output.errorThrown) {
     throw output.errorThrown;
   }
@@ -58,7 +58,7 @@ const runAssertions = (step, output) => {
   }
 
   if (step.expectedValue) {
-    assert.deepEqual(output.value, step.expectedValue);
+    deepEqual(output.value, step.expectedValue);
   }
 };
 

--- a/step-manager.js
+++ b/step-manager.js
@@ -1,4 +1,4 @@
-const assert = require('assert-diff');
+const Runner = require('./runner');
 
 module.exports = class StepManager {
   constructor(generator, args) {
@@ -15,6 +15,7 @@ module.exports = class StepManager {
     this.steps.push({
       result,
       expectedValue,
+      stack: getCallStack('yields'),
     });
 
     return this;
@@ -24,6 +25,7 @@ module.exports = class StepManager {
     this.steps.push({
       error,
       expectedValue,
+      stack: getCallStack('catches'),
     });
 
     return this;
@@ -33,6 +35,7 @@ module.exports = class StepManager {
     this.steps.push({
       error,
       expectedThrow: true,
+      stack: getCallStack('throws'),
     });
 
     return this;
@@ -43,13 +46,17 @@ module.exports = class StepManager {
       error,
       expectedValue,
       expectedDone: true,
+      stack: getCallStack('catchesAndFinishes'),
     });
 
     return this;
   }
 
   next(result) {
-    this.steps.push({ result });
+    this.steps.push({
+      result,
+      stack: getCallStack('next'),
+    });
     return this;
   }
 
@@ -57,6 +64,7 @@ module.exports = class StepManager {
     this.steps.push({
       expectedValue,
       expectedDone: true,
+      stack: getCallStack('finishes'),
     });
 
     return this;
@@ -73,66 +81,14 @@ module.exports = class StepManager {
   }
 }
 
-class Runner {
-  constructor(it, steps) {
-    this.it = it;
-    this.steps = steps;
-    this.results = [];
-    this.isDone = false;
-  }
+const getCallStack = (message) => {
+  const err = new Error(message);
+  if (!err || !err.stack) return message;
 
-  run() {
-    const { it, steps } = this;
+  const stack = err.stack
+    .split('\n')
+    .slice(2, 10)
+    .join('\n');
 
-    steps.reduce((prevResult, step) => {
-      if (this.isDone) throwExtraStep(step);
-      const output = runStep(it, step, prevResult);
-
-      runAssertions(step, output);
-
-      if (output.done) this.isDone = true;
-
-      this.results.push(output);
-      return step.result;
-    }, null);
-
-    return this.results;
-  }
+  return stack;
 }
-
-const runStep = (it, step, prevResult) => {
-  if (step.error) {
-    try {
-      return it.throw(step.error);
-    } catch (error) {
-      return {
-        errorThrown: error,
-      };
-    }
-  }
-
-  return it.next(prevResult);
-}
-
-const runAssertions = (step, output) => {
-  if (step.expectedThrow) {
-    assert.deepEqual(output.errorThrown, step.error);
-  } else if (output.errorThrown) {
-    throw output.errorThrown;
-  }
-
-  if (step.expectedDone) {
-    assert.equal(output.done, true);
-  }
-
-  if (step.expectedValue) {
-    assert.deepEqual(output.value, step.expectedValue);
-  }
-};
-
-const throwExtraStep = (step) => {
-  throw new Error({
-    message: 'Too many steps were provided for the generator',
-    failedOnStep: step,
-  });
-};

--- a/step-manager.js
+++ b/step-manager.js
@@ -1,12 +1,17 @@
 const Runner = require('./runner');
 
 module.exports = class StepManager {
-  constructor(generator, args) {
+  constructor({
+    generator,
+    args,
+    deepEqual,
+  }) {
     if (!generator) {
       throw new Error(`ExpectGen requires an generator, passed in ${generator}`);
     }
 
     this.generator = generator;
+    this.deepEqual = deepEqual;
     this.args = args;
     this.steps = [];
   }
@@ -72,7 +77,7 @@ module.exports = class StepManager {
 
   run(context = null) {
     const it = this.generator.apply(context, this.args);
-    const runner = new Runner(it, this.steps);
+    const runner = new Runner(it, this.steps, this.deepEqual);
     return runner.run();
   }
 

--- a/test/__snapshots__/step-manager.test.js.snap
+++ b/test/__snapshots__/step-manager.test.js.snap
@@ -1,19 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`StepManager #yields when it wont pass throws on run 1`] = `
-"{ PUT: 
-   { channel: null,
-     action: { payload: [Object], type: 'LOADING' } } } deepEqual { PUT: { channel: null, action: { payload: [], type: 'LOADING' } } }[m
- {
-   PUT: {
-     action: {
-       payload: [
-[32m+        1[39m
-[32m+        2[39m
-[32m+        3[39m
-       ]
-     }
-   }
- }
-"
-`;
+exports[`StepManager when more steps are expected but generator is done throws 1`] = `"Too many steps were provided for the generator"`;

--- a/test/step-manager.test.js
+++ b/test/step-manager.test.js
@@ -1,7 +1,7 @@
 const { put } = require('redux-saga/effects');
 const assert = require('assert-diff');
 const StepManager = require('../step-manager');
-
+const { deepEqual } = assert;
 function startLoading(ids) {
   return {
     payload: ids,
@@ -26,7 +26,11 @@ describe('StepManager', () => {
   beforeEach(() => {
     ids = [1, 2, 3];
     args = [ids];
-    stepManager = new StepManager(myEffect, args);
+    stepManager = new StepManager({
+      generator: myEffect,
+      args,
+      deepEqual,
+    });
   });
 
   it('stores args arguments', () => {
@@ -49,13 +53,6 @@ describe('StepManager', () => {
       it('adds step with an expectedValue and a result', () => {
         expect(stepManager.steps.length).toEqual(1);
         expect(stepManager.steps[0].expectedValue).toBe(yieldedVal);
-      });
-
-      it('calls assert on run', () => {
-        const assertSpy = spyOn(assert, 'deepEqual');
-
-        stepManager.run();
-        expect(assertSpy).toHaveBeenCalled();
       });
     });
 
@@ -80,7 +77,11 @@ describe('StepManager', () => {
     beforeEach(() => {
       ids = [1, 2, 3];
       args = [ids];
-      stepManager = new StepManager(myEffect2, args)
+      stepManager = new StepManager({
+        generator: myEffect2,
+        args,
+        deepEqual,
+      })
         .next('123');
     });
 
@@ -117,7 +118,11 @@ describe('StepManager', () => {
 
     describe('#catches', () => {
       beforeEach(() => {
-        stepManager = new StepManager(errEffect, args)
+        stepManager = new StepManager({
+          generator: errEffect,
+          args,
+          deepEqual,
+        })
           .next()
           .catches(myError, 'CAUGHT');
       });
@@ -146,7 +151,11 @@ describe('StepManager', () => {
       };
 
       beforeEach(() => {
-        stepManager = new StepManager(errFinishEffect, args)
+        stepManager = new StepManager({
+          generator: errFinishEffect,
+          args,
+          deepEqual,
+        })
           .next()
           .catchesAndFinishes(myError, 'CAUGHT');
       });
@@ -164,7 +173,11 @@ describe('StepManager', () => {
 
     describe('#throws', () => {
       beforeEach(() => {
-        stepManager = new StepManager(myEffect, args)
+        stepManager = new StepManager({
+          generator: myEffect,
+          args,
+          deepEqual,
+        })
           .next()
           .throws(myError);
       });
@@ -185,7 +198,11 @@ describe('StepManager', () => {
     beforeEach(() => {
       ids = [1, 2, 3];
       args = [ids];
-      stepManager = new StepManager(myEffect2, args)
+      stepManager = new StepManager({
+        generator: myEffect2,
+        args,
+        deepEqual,
+      })
         .next('123')
         .finishes('123');
     });
@@ -196,7 +213,11 @@ describe('StepManager', () => {
     });
 
     it('fails assertion when generator not complete', () => {
-      stepManager = new StepManager(myEffect2, args)
+      stepManager = new StepManager({
+        generator: myEffect2,
+        args,
+        deepEqual,
+      })
         .finishes('123');
       expect(() => stepManager.run()).toThrow();
     });
@@ -204,7 +225,11 @@ describe('StepManager', () => {
 
   describe('when more steps are expected but generator is done', () => {
     it('throws', () => {
-      stepManager = new StepManager(myEffect2, args)
+      stepManager = new StepManager({
+        generator: myEffect2,
+        args,
+        deepEqual,
+      })
         .next()
         .next()
         .next();

--- a/test/step-manager.test.js
+++ b/test/step-manager.test.js
@@ -66,7 +66,7 @@ describe('StepManager', () => {
       });
 
       it('throws on run', () => {
-        expect(() => stepManager.run()).toThrowErrorMatchingSnapshot();
+        expect(() => stepManager.run()).toThrow();
       });
     });
   });
@@ -181,8 +181,6 @@ describe('StepManager', () => {
     });
   });
 
-
-
   describe('#finishes', () => {
     beforeEach(() => {
       ids = [1, 2, 3];
@@ -210,7 +208,7 @@ describe('StepManager', () => {
         .next()
         .next()
         .next();
-      expect(() => stepManager.run()).toThrow();
+      expect(() => stepManager.run()).toThrowErrorMatchingSnapshot();
     });
   });
 });


### PR DESCRIPTION
https://github.com/jimbol/expect-gen/issues/17

- We were throwing cryptic `[Object object]` errors. Those have been replaced with readable string errors.
- Include 10 lines of call stack with errors
- Move runner into its own file