### PR TITLE
dont swallow error messages

### DIFF
--- a/runner.js
+++ b/runner.js
@@ -18,7 +18,7 @@ module.exports = class Runner {
         output = runStep(it, step, prevResult);
         runAssertions(step, output, this.deepEqual);
       } catch (err) {
-        err.stack = `\n\nStack:\n${step.stack}`;
+        err.stack = `${err.message}\n${step.stack}`;
         throw err;
       }
 

--- a/test/step-manager.test.js
+++ b/test/step-manager.test.js
@@ -233,6 +233,7 @@ describe('StepManager', () => {
         .next()
         .next()
         .next();
+
       expect(() => stepManager.run()).toThrowErrorMatchingSnapshot();
     });
   });


### PR DESCRIPTION
Error messages were getting thrown as part of the stack replacement scheme. This includes the message in the new stack.