### PR TITLE
v0.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "expect-gen",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Assertion library for unit testing JS generators. Works well with redux-saga. Allows snapshot testing.",
   "devDependencies": {
     "jest": "^19.0.2",


### PR DESCRIPTION
`yarn publish` added an unwanted `user` dependency, this bump does not include that.